### PR TITLE
Update Branch Name To 'master'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Follow these steps:
 
 ## Making Changes
 
-* Create a topic branch off of `main` before you start your work.
-    - Please avoid working directly on the `main` branch.
+* Create a topic branch off of `master` before you start your work.
+    - Please avoid working directly on the `master` branch.
 * Make commits of logical units.
     - You may be asked to squash unnecessary commits down to logical units.
 * Check for unnecessary whitespace with `git diff --check` before committing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fastlane roku_app_util plugin
 
-[![Test](https://github.com/WarnerMedia/fastlane-plugin-roku_app_util/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/WarnerMedia/fastlane-plugin-roku_app_util/actions/workflows/test.yml)
+[![Test](https://github.com/WarnerMedia/fastlane-plugin-roku_app_util/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/WarnerMedia/fastlane-plugin-roku_app_util/actions/workflows/test.yml)
 <!-- [![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-roku_app_util) -->
 
 ## Getting Started


### PR DESCRIPTION
To help simplify use/adoption of this plugin, the default branch has been renamed from `main` to `master` due to assumptions made within Fastlane's plugin system (it looks for a `master` branch by default). This updates references from `main` to `master` to reflect the new default branch.