### PR TITLE
feat: add pkg_output_path param on roku_app_package function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Key  | Environment Variable Equivalent | Description | Required?
 `sign_key`    | `ROKUAPPUTIL_SIGN_KEY`   | Roku signing key | YES
 `app_name`    | `ROKUAPPUTIL_APP_NAME`   | Roku application name | YES
 `app_version` | `ROKUAPPUTIL_APP_VERSION`| Roku application version | YES
+`pkg_output_path` | `ROKUAPPUTIL_PKG_OUTPUT_PATH`| Roku application PKG path | NO - Default value: `./`
 
 ## Example
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,5 +24,6 @@ lane :test do
     sign_key: "secret",           # or set environment variable ROKUAPPUTIL_SIGN_KEY
     app_name: "Your Snazzy App",  # or set environment variable ROKUAPPUTIL_APP_NAME
     app_version: "1.2.3"          # or set environment variable ROKUAPPUTIL_APP_VERSION
+    pkg_output_path: "/path/to/pkg/target/location"          # or set environment variable ROKUAPPUTIL_APP_VERSION
   )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,6 +24,6 @@ lane :test do
     sign_key: "secret",           # or set environment variable ROKUAPPUTIL_SIGN_KEY
     app_name: "Your Snazzy App",  # or set environment variable ROKUAPPUTIL_APP_NAME
     app_version: "1.2.3"          # or set environment variable ROKUAPPUTIL_APP_VERSION
-    pkg_output_path: "/path/to/pkg/target/location"          # or set environment variable ROKUAPPUTIL_APP_VERSION
+    pkg_output_path: "/path/to/pkg/target/location" # or set environment variable ROKUAPPUTIL_PKG_OUTPUT_PATH
   )
 end

--- a/lib/fastlane/plugin/roku_app_util/actions/roku_app_package_action.rb
+++ b/lib/fastlane/plugin/roku_app_util/actions/roku_app_package_action.rb
@@ -71,7 +71,13 @@ module Fastlane
                                   env_name: "ROKUAPPUTIL_APP_VERSION",
                                description: "Roku application version",
                                   optional: true,
-                                      type: String)
+                                      type: String),
+          FastlaneCore::ConfigItem.new(key: :pkg_output_path,
+                                  env_name: "ROKUAPPUTIL_PKG_OUTPUT_PATH",
+                               description: "Output path for pkg",
+                                  optional: true,
+                                      type: String,
+                                      default_value: "./")
         ]
       end
 

--- a/lib/fastlane/plugin/roku_app_util/helper/roku_app_util_helper.rb
+++ b/lib/fastlane/plugin/roku_app_util/helper/roku_app_util_helper.rb
@@ -123,6 +123,8 @@ module Fastlane
         app_name = params[:app_name]
         # application version
         app_version = params[:app_version]
+        # pkg_output_path: default to current folder        
+        pkg_output_path = params[:pkg_output_path]
 
         user_pass = "#{user}:#{pass}"
         app_name_version = "#{app_name}/#{app_version}"
@@ -152,8 +154,8 @@ module Fastlane
 
         # Use a combination of the app name & version for the output package file name
         output_package_file = "#{app_name}_#{app_version}.pkg".gsub(' ', '_')
-        # Head up one directory level
-        Dir.chdir("..") do
+        # download and rename package to pkg_output_path
+        Dir.chdir(pkg_output_path) do
           `curl --user #{user_pass} --digest --silent --show-error --output #{output_package_file} http://#{target}/pkgs/#{package_name}`
           # Check exit code
           if $?.exitstatus != 0


### PR DESCRIPTION
# feat: add pkg_output_path param on roku_app_package function

## Fixes # (3)
Solving [Bug: Executing roku_app_packageoutput the pkg in wrong path](https://github.com/WarnerMedia/fastlane-plugin-roku_app_util/issues/3)

## Description
Added a `pkg_output_path` variable on the `roku_app_package` function to set a different target location for the pkg.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
